### PR TITLE
Fix(standby.js): 타이핑 정지 효과 이슈 수정

### DIFF
--- a/javascript/standby.js
+++ b/javascript/standby.js
@@ -48,8 +48,8 @@ const typingText = () => {
 };
 
 const disableStandby = () => {
-  $standbyScreen.classList.add("disabled");
   clearInterval(typingInterval);
+  $standbyScreen.classList.add("disabled");
 };
 
 const changeBbeggomImage = (e) => {


### PR DESCRIPTION
- 확인 버튼을 눌러도 타이핑 효과 비활성화가 되지 않는 이슈가 발생 -> clearInterval 순서 수정