### PR TITLE
Fix(spinner.js): 글씨가 번지는 현상 수정

### DIFF
--- a/javascript/spinner.js
+++ b/javascript/spinner.js
@@ -39,7 +39,10 @@ class Spinner {
     const size = products.size;
     const radian = ((360 / size) * Math.PI) / 180; // Average radian of total product
 
-    ctx.clearRect(0, 0, $canvas.width * 2, $canvas.height * 2);
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, $canvas.width, $canvas.height);
+    ctx.restore();
 
     for (const key of products.items.keys()) {
       const product = products.getItem(key);


### PR DESCRIPTION
## Fix
- translate 영향으로 음수 영역에 있는 (캔버스 -x, -y) 텍스트는 clearRect의 영향을 받지 않아 그대로 번지는 현상 발생
- fix -> 지우기 전 현재 상태를 저장하고 setTransform 메서드로 형태를 변경하여 지우기를 시도 -> restore 메서드로 복구 및 이슈 해결